### PR TITLE
Argumented component presenter

### DIFF
--- a/app/src/main/java/com/xfinity/blueprint_sample/mvp/presenter/DataItemPresenter.kt
+++ b/app/src/main/java/com/xfinity/blueprint_sample/mvp/presenter/DataItemPresenter.kt
@@ -13,26 +13,20 @@ package com.xfinity.blueprint_sample.mvp.presenter
 
 import com.xfinity.blueprint.event.ComponentEvent
 import com.xfinity.blueprint.event.ComponentEventManager
-import com.xfinity.blueprint.model.ComponentModel
 import com.xfinity.blueprint.presenter.EventEmittingComponentPresenter
-import com.xfinity.blueprint.view.ComponentView
 import com.xfinity.blueprint_sample.mvp.model.DataItemModel
 import com.xfinity.blueprint_sample.mvp.view.DataItemView
 
-class DataItemPresenter(componentEventManager: ComponentEventManager) :
-        EventEmittingComponentPresenter(componentEventManager) {
-    override fun present(componentView: ComponentView<*>, componentModel: ComponentModel) {
-        (componentView as DataItemView).setData((componentModel as DataItemModel).data)
-    }
+class DataItemPresenter(override val componentEventManager: ComponentEventManager) :
+        EventEmittingComponentPresenter<DataItemView, DataItemModel> {
 
-    override fun onComponentClicked(componentView: ComponentView<*>, position: Int) {
-        if (componentView is DataItemView) {
-            componentView.setData("Component $position was clicked")
+    override fun present(view: DataItemView, model: DataItemModel) {
+        view.setData(model.data)
+        view.setBehavior { position ->
+            view.setData("Component $position was clicked")
+            componentEventManager.postEvent(DataItemClickedEvent("This is the event for position $position"))
         }
-
-        componentEventManager.postEvent(DataItemClickedEvent("This is the event for position $position"))
     }
-
 
     data class DataItemClickedEvent(val toast: String) : ComponentEvent
 }

--- a/app/src/main/java/com/xfinity/blueprint_sample/mvp/presenter/DefaultDataItemPresenter.kt
+++ b/app/src/main/java/com/xfinity/blueprint_sample/mvp/presenter/DefaultDataItemPresenter.kt
@@ -12,9 +12,7 @@
 package com.xfinity.blueprint_sample.mvp.presenter
 
 import com.xfinity.blueprint.event.ComponentEventManager
-import com.xfinity.blueprint.model.ComponentModel
 import com.xfinity.blueprint.presenter.EventEmittingComponentPresenter
-import com.xfinity.blueprint.view.ComponentView
 import com.xfinity.blueprint_annotations.DefaultPresenter
 import com.xfinity.blueprint_annotations.DefaultPresenterConstructor
 import com.xfinity.blueprint_sample.mvp.model.DataItemModel
@@ -22,23 +20,22 @@ import com.xfinity.blueprint_sample.mvp.view.DataItemView
 
 @DefaultPresenter(viewClass = DataItemView::class)
 class DefaultDataItemPresenter
-@DefaultPresenterConstructor constructor(componentEventManager: ComponentEventManager,
-                                         val defaultDataItemName: String,
-                                         val defaultDataItemId: Int) :
-        EventEmittingComponentPresenter(componentEventManager) {
-    override fun present(componentView: ComponentView<*>, componentModel: ComponentModel) {
-        if ((componentModel as DataItemModel).data.isEmpty()) {
-            (componentView as DataItemView).setData(defaultDataItemName + defaultDataItemId)
+@DefaultPresenterConstructor constructor(override val componentEventManager: ComponentEventManager,
+                                         private val defaultDataItemName: String,
+                                         private val defaultDataItemId: Int) :
+        EventEmittingComponentPresenter<DataItemView, DataItemModel> {
+
+    override fun present(view: DataItemView, model: DataItemModel) {
+
+        if (model.data.isEmpty()) {
+            view.setData(defaultDataItemName + defaultDataItemId)
         } else {
-            (componentView as DataItemView).setData(componentModel.data)
-        }
-    }
-
-    override fun onComponentClicked(componentView: ComponentView<*>, position: Int) {
-        if (componentView is DataItemView) {
-            componentView.setData("Component $position was clicked")
+            view.setData(model.data)
         }
 
-        componentEventManager.postEvent(DataItemPresenter.DataItemClickedEvent("default data item clicked"))
+        view.setBehavior { position ->
+            view.setData("Component $position was clicked")
+            componentEventManager.postEvent(DataItemPresenter.DataItemClickedEvent("default data item clicked"))
+        }
     }
 }

--- a/app/src/main/java/com/xfinity/blueprint_sample/mvp/presenter/FooterPresenter.kt
+++ b/app/src/main/java/com/xfinity/blueprint_sample/mvp/presenter/FooterPresenter.kt
@@ -11,20 +11,14 @@
 
 package com.xfinity.blueprint_sample.mvp.presenter
 
+import com.xfinity.blueprint.presenter.ComponentPresenter
+import com.xfinity.blueprint_annotations.DefaultPresenter
 import com.xfinity.blueprint_sample.mvp.model.FooterModel
 import com.xfinity.blueprint_sample.mvp.view.FooterView
-import com.xfinity.blueprint.model.ComponentModel
-import com.xfinity.blueprint.presenter.ComponentPresenter
-import com.xfinity.blueprint.view.ComponentView
-import com.xfinity.blueprint_annotations.DefaultPresenter
 
 @DefaultPresenter(viewClass = FooterView::class)
-class FooterPresenter : ComponentPresenter {
-    override fun present(componentView: ComponentView<*>, componentModel: ComponentModel) {
-        (componentView as FooterView).setFooter((componentModel as FooterModel).footer)
-    }
-
-    override fun onComponentClicked(componentView: ComponentView<*>, position: Int) {
-        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+class FooterPresenter : ComponentPresenter<FooterView, FooterModel> {
+    override fun present(view: FooterView, model: FooterModel) {
+        view.setFooter(model.footer)
     }
 }

--- a/app/src/main/java/com/xfinity/blueprint_sample/mvp/presenter/HeaderPresenter.kt
+++ b/app/src/main/java/com/xfinity/blueprint_sample/mvp/presenter/HeaderPresenter.kt
@@ -11,25 +11,15 @@
 
 package com.xfinity.blueprint_sample.mvp.presenter
 
-import com.xfinity.blueprint.model.ComponentModel
 import com.xfinity.blueprint.presenter.ComponentPresenter
-import com.xfinity.blueprint.view.ComponentView
 import com.xfinity.blueprint_annotations.DefaultPresenter
 import com.xfinity.blueprint_sample.mvp.model.HeaderModel
 import com.xfinity.blueprint_sample.mvp.view.HeaderView
 
 @DefaultPresenter(viewClass = HeaderView::class)
-class HeaderPresenter : ComponentPresenter {
-    override fun present(componentView: ComponentView<*>, componentModel: ComponentModel) {
-        (componentView as HeaderView).setEnabled((componentModel as HeaderModel).enabled)
-
-        if (componentModel.enabled) {
-            componentView.setEnabled(true)
-            componentView.setHeader(componentModel.header)
-        }
-    }
-
-    override fun onComponentClicked(componentView: ComponentView<*>, position: Int) {
-        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+class HeaderPresenter : ComponentPresenter<HeaderView, HeaderModel> {
+    override fun present(view: HeaderView, model: HeaderModel) {
+        view.setEnabled(model.enabled)
+        view.setHeader(model.header)
     }
 }

--- a/app/src/main/java/com/xfinity/blueprint_sample/mvp/view/DataItemView.kt
+++ b/app/src/main/java/com/xfinity/blueprint_sample/mvp/view/DataItemView.kt
@@ -16,14 +16,16 @@ import android.view.View
 import android.widget.TextView
 import com.xfinity.blueprint_annotations.ComponentViewClass
 import com.xfinity.blueprint_annotations.ComponentViewHolder
-import com.xfinity.blueprint_annotations.ClickableComponentBinder
 import com.xfinity.blueprint_sample.R
 
-@ClickableComponentBinder
 @ComponentViewClass(viewHolderClass = DataItemViewHolder::class)
 class DataItemView : DataItemViewBase() {
     fun setData(data: String) {
         viewHolder.textView.text = data
+    }
+
+    fun setBehavior(behavior: (position: Int) -> Unit) {
+        viewHolder.itemView.setOnClickListener { behavior.invoke(viewHolder.adapterPosition) }
     }
 }
 

--- a/app/src/main/java/com/xfinity/blueprint_sample/mvp/view/LoadingDotsView.kt
+++ b/app/src/main/java/com/xfinity/blueprint_sample/mvp/view/LoadingDotsView.kt
@@ -13,6 +13,7 @@ package com.xfinity.blueprint_sample.mvp.view
 
 import android.support.v7.widget.RecyclerView
 import android.view.View
+import com.xfinity.blueprint.model.ComponentModel
 import com.xfinity.blueprint.presenter.ComponentPresenter
 import com.xfinity.blueprint.view.ComponentView
 import com.xfinity.blueprint.view.ComponentViewBinder
@@ -29,7 +30,10 @@ class LoadingDotsViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView)
 
 @ComponentViewHolderBinder
 class LoadingDotsViewBinder : ComponentViewBinder<LoadingDotsViewHolder> {
-    override fun bind(componentPresenter: ComponentPresenter, componentView: ComponentView<out LoadingDotsViewHolder>, viewHolder: LoadingDotsViewHolder, position: Int) {
+
+    override fun bind(componentPresenter: ComponentPresenter<ComponentView<*>, ComponentModel>,
+                      componentView: ComponentView<out LoadingDotsViewHolder>,
+                      viewHolder: LoadingDotsViewHolder, position: Int) {
         //if there were any binding, it would go here
     }
 }

--- a/library/src/main/java/com/xfinity/blueprint/ComponentAdapter.kt
+++ b/library/src/main/java/com/xfinity/blueprint/ComponentAdapter.kt
@@ -14,13 +14,14 @@ package com.xfinity.blueprint
 import android.support.v7.widget.RecyclerView
 import android.view.ViewGroup
 import com.xfinity.blueprint.model.Component
+import com.xfinity.blueprint.model.ComponentModel
 import com.xfinity.blueprint.presenter.ComponentPresenter
 import com.xfinity.blueprint.view.ComponentView
 
 open class ComponentAdapter : RecyclerView.Adapter<RecyclerView.ViewHolder> {
     private val componentRegistry: ComponentRegistry
 
-    private val presenterMap = mutableMapOf<Int, ComponentPresenter>()
+    private val presenterMap = mutableMapOf<Int, ComponentPresenter<ComponentView<*>, ComponentModel>>()
     internal val components = mutableListOf<Component>()
     private val componentViews = mutableListOf<ComponentView<RecyclerView.ViewHolder>>()
 
@@ -44,8 +45,16 @@ open class ComponentAdapter : RecyclerView.Adapter<RecyclerView.ViewHolder> {
 
     override fun onBindViewHolder(holder: RecyclerView.ViewHolder, position: Int) {
         val componentView = componentViews[position]
-        val presenter: ComponentPresenter = components[position].presenter ?: presenterMap[componentView.getViewType()] ?:
-                throw IllegalStateException("Presenter for " + componentView.javaClass.simpleName + " is null.")
+
+        val presenter: ComponentPresenter<ComponentView<*>, ComponentModel> = components[position].presenter?.let {
+            try {
+                @Suppress("UNCHECKED_CAST")
+                it as ComponentPresenter<ComponentView<*>, ComponentModel>
+            } catch (e: ClassCastException) {
+                throw ClassCastException("Presenter for ${componentView.javaClass.simpleName} is unsupported. ${e.message}")
+            }
+        } ?: presenterMap[componentView.getViewType()]
+        ?: throw IllegalStateException("Presenter for " + componentView.javaClass.simpleName + " is null.")
 
         val componentModel = components[position].model
 
@@ -168,7 +177,7 @@ open class ComponentAdapter : RecyclerView.Adapter<RecyclerView.ViewHolder> {
 
     fun clear(notify: Boolean) {
         val count = itemCount
-        
+
         components.clear()
         componentViews.clear()
         if (notify) {

--- a/library/src/main/java/com/xfinity/blueprint/ComponentRegistry.kt
+++ b/library/src/main/java/com/xfinity/blueprint/ComponentRegistry.kt
@@ -12,11 +12,12 @@
 package com.xfinity.blueprint
 
 import android.support.v7.widget.RecyclerView
+import com.xfinity.blueprint.model.ComponentModel
 import com.xfinity.blueprint.presenter.ComponentPresenter
 import com.xfinity.blueprint.view.ComponentView
 
 interface ComponentRegistry {
-    fun getComponentView(viewType: Int) : ComponentView<RecyclerView.ViewHolder>?
-    fun getDefaultPresenter(viewType: Int, vararg args : Any) : ComponentPresenter?
-    fun getDefaultPresenter(componentView: ComponentView<RecyclerView.ViewHolder>, vararg args : Any): ComponentPresenter?
+    fun getComponentView(viewType: Int): ComponentView<RecyclerView.ViewHolder>?
+    fun getDefaultPresenter(viewType: Int, vararg args: Any): ComponentPresenter<ComponentView<*>, ComponentModel>?
+    fun getDefaultPresenter(componentView: ComponentView<RecyclerView.ViewHolder>, vararg args: Any): ComponentPresenter<ComponentView<*>, ComponentModel>?
 }

--- a/library/src/main/java/com/xfinity/blueprint/model/Component.kt
+++ b/library/src/main/java/com/xfinity/blueprint/model/Component.kt
@@ -15,4 +15,6 @@ import com.xfinity.blueprint.presenter.ComponentPresenter
 
 interface ComponentModel
 
-data class Component(val model: ComponentModel, val viewType: Int, val presenter: ComponentPresenter? = null)
+data class Component(val model: ComponentModel,
+                     val viewType: Int,
+                     val presenter: ComponentPresenter<*, *>? = null)

--- a/library/src/main/java/com/xfinity/blueprint/presenter/ComponentPresenter.kt
+++ b/library/src/main/java/com/xfinity/blueprint/presenter/ComponentPresenter.kt
@@ -14,7 +14,6 @@ package com.xfinity.blueprint.presenter
 import com.xfinity.blueprint.model.ComponentModel
 import com.xfinity.blueprint.view.ComponentView
 
-interface ComponentPresenter {
-    fun present(componentView: ComponentView<*>, componentModel: ComponentModel)
-    fun onComponentClicked(componentView: ComponentView<*>, position: Int)
+interface ComponentPresenter<in V : ComponentView<*>, in M : ComponentModel> {
+    fun present(view: V, model: M)
 }

--- a/library/src/main/java/com/xfinity/blueprint/presenter/DefaultComponentPresenter.kt
+++ b/library/src/main/java/com/xfinity/blueprint/presenter/DefaultComponentPresenter.kt
@@ -14,7 +14,6 @@ package com.xfinity.blueprint.presenter
 import com.xfinity.blueprint.model.ComponentModel
 import com.xfinity.blueprint.view.ComponentView
 
-open class DefaultComponentPresenter : ComponentPresenter {
-    override fun present(componentView: ComponentView<*>, componentModel: ComponentModel) {}
-    override fun onComponentClicked(componentView: ComponentView<*>, position: Int) {}
+open class DefaultComponentPresenter : ComponentPresenter<ComponentView<*>, ComponentModel> {
+    override fun present(view: ComponentView<*>, model: ComponentModel) {}
 }

--- a/library/src/main/java/com/xfinity/blueprint/presenter/EventEmittingComponentPresenter.kt
+++ b/library/src/main/java/com/xfinity/blueprint/presenter/EventEmittingComponentPresenter.kt
@@ -12,5 +12,10 @@
 package com.xfinity.blueprint.presenter
 
 import com.xfinity.blueprint.event.ComponentEventManager
+import com.xfinity.blueprint.model.ComponentModel
+import com.xfinity.blueprint.view.ComponentView
 
-abstract class EventEmittingComponentPresenter(val componentEventManager: ComponentEventManager) : ComponentPresenter
+
+interface EventEmittingComponentPresenter<in V : ComponentView<*>, in M : ComponentModel> : ComponentPresenter<V, M> {
+    val componentEventManager: ComponentEventManager
+}

--- a/library/src/main/java/com/xfinity/blueprint/view/ComponentView.kt
+++ b/library/src/main/java/com/xfinity/blueprint/view/ComponentView.kt
@@ -13,6 +13,7 @@ package com.xfinity.blueprint.view
 
 import android.support.v7.widget.RecyclerView
 import android.view.ViewGroup
+import com.xfinity.blueprint.model.ComponentModel
 import com.xfinity.blueprint.presenter.ComponentPresenter
 
 /**
@@ -22,6 +23,6 @@ interface ComponentView<T : RecyclerView.ViewHolder> {
     var viewHolder: T
     val componentViewBinder: ComponentViewBinder<T>
     fun onCreateViewHolder(parent: ViewGroup) : T
-    fun onBindViewHolder(componentPresenter: ComponentPresenter, viewHolder: RecyclerView.ViewHolder, position: Int)
+    fun onBindViewHolder(componentPresenter: ComponentPresenter<ComponentView<*>, ComponentModel>, viewHolder: RecyclerView.ViewHolder, position: Int)
     fun getViewType() : Int
 }

--- a/library/src/main/java/com/xfinity/blueprint/view/ComponentViewBinder.kt
+++ b/library/src/main/java/com/xfinity/blueprint/view/ComponentViewBinder.kt
@@ -12,16 +12,17 @@
 package com.xfinity.blueprint.view
 
 import android.support.v7.widget.RecyclerView
+import com.xfinity.blueprint.model.ComponentModel
 import com.xfinity.blueprint.presenter.ComponentPresenter
 
 interface ComponentViewBinder<in T : RecyclerView.ViewHolder> {
-    fun bind(componentPresenter: ComponentPresenter, componentView: ComponentView<out T>, viewHolder: T, position: Int)
+    fun bind(componentPresenter: ComponentPresenter<ComponentView<*>, ComponentModel>,
+             componentView: ComponentView<out T>, viewHolder: T, position: Int)
 }
 
 class ClickableComponentViewBinder : ComponentViewBinder<RecyclerView.ViewHolder> {
-    override fun bind(componentPresenter: ComponentPresenter,
+    override fun bind(componentPresenter: ComponentPresenter<ComponentView<*>, ComponentModel>,
                       componentView: ComponentView<out RecyclerView.ViewHolder>,
                       viewHolder: RecyclerView.ViewHolder, position: Int) {
-        viewHolder.itemView.setOnClickListener { componentPresenter.onComponentClicked(componentView, position) }
     }
 }


### PR DESCRIPTION
#### This is the first solution proposal to the issue to acquire true types of views and models in the component presenters.

The only problem I faced is to inherit the **ComponentPresenter** and add to a **Component** which requires parental type that will be ignored when inherited class/interface uses type arguments to achieve same functionality of **ComponentPresenter**. Therefore, I declared the presenter by star projection in **Component** data class. Unfortunately, this also forces **ComponentAdapter** to cast the presenter to **ComponentPresenter** with arguments **ComponentView** and **ComponentModel**.

An use case can be when we want to use EventEmittingComponentPresenter. For example:
https://github.com/Comcast/blueprint/blob/38cf4ce82f84545bc4d401d84d51eabc07935e77/app/src/main/java/com/xfinity/blueprint_sample/mvp/presenter/DynamicScreenPresenter.kt#L68-L69
Without **star projection** dataItemPresenter object will be mismatched type.