### PR TITLE
Auto-generate Android SDK agnostic view visibility functions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,13 +1,13 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.kotlin_version = '1.2.41'
+    ext.kotlin_version = '1.2.70'
     repositories {
         jcenter()
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.3'
+        classpath 'com.android.tools.build:gradle:3.1.4'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ allprojects {
     apply plugin: 'maven'
 
     group = 'com.xfinity'
-    version = '1.1.0'
+    version = '1.2.0'
 }
 
 ext {
@@ -32,6 +32,6 @@ ext {
     groupId = 'com.xfinity'
     projectName = 'Blueprint'
     uploadName = 'blueprint'
-    publishVersion = '1.1.0'
+    publishVersion = '1.2.0'
     description = 'Blueprint for Android'
 }

--- a/compiler/src/main/java/com/xfinity/blueprint_compiler/CodeGenerator.java
+++ b/compiler/src/main/java/com/xfinity/blueprint_compiler/CodeGenerator.java
@@ -11,6 +11,7 @@
 
 package com.xfinity.blueprint_compiler;
 
+import com.squareup.javapoet.AnnotationSpec;
 import com.squareup.javapoet.ArrayTypeName;
 import com.squareup.javapoet.ClassName;
 import com.squareup.javapoet.FieldSpec;
@@ -309,6 +310,9 @@ final class CodeGenerator {
                     }
 
                     methods.add(getSetVisibilityMethodSpec(childCapitalized, childGetter));
+                    methods.add(getMakeVisibleMethodSpec(childCapitalized, childGetter));
+                    methods.add(getMakeGoneMethodSpec(childCapitalized, childGetter));
+                    methods.add(getMakeInvisibleMethodSpec(childCapitalized, childGetter));
                     methods.add(getSetBackgroundColorMethodSpec(childCapitalized, childGetter));
                 }
             }
@@ -345,12 +349,41 @@ final class CodeGenerator {
         ParameterSpec visibilityParam =
                 ParameterSpec.builder(INT, "visibility").build();
 
+        AnnotationSpec deprecatedAnnotation = AnnotationSpec.builder(ClassName.get("java.lang", "Deprecated")).build();
+
         return MethodSpec.methodBuilder("set" + childName + "Visibility")
+                          .addJavadoc("@deprecated.  Use make$LVisible(), make$LInvisible(), or make$LGone() instead", childName,
+                                      childName, childName)
+                          .addAnnotation(deprecatedAnnotation)
                           .addModifiers(PUBLIC)
                           .addParameter(visibilityParam)
                           .returns(VOID)
                           .addStatement("viewHolder." + childGetterName + ".setVisibility(visibility)")
                           .build();
+    }
+
+    private MethodSpec getMakeVisibleMethodSpec(String childName, String childGetterName) {
+        return MethodSpec.methodBuilder("make" + childName + "Visible")
+                         .addModifiers(PUBLIC)
+                         .returns(VOID)
+                         .addStatement("viewHolder." + childGetterName + ".setVisibility(android.view.View.VISIBLE)")
+                         .build();
+    }
+
+    private MethodSpec getMakeGoneMethodSpec(String childName, String childGetterName) {
+        return MethodSpec.methodBuilder("make" + childName + "Gone")
+                         .addModifiers(PUBLIC)
+                         .returns(VOID)
+                         .addStatement("viewHolder." + childGetterName + ".setVisibility(android.view.View.GONE)")
+                         .build();
+    }
+
+    private MethodSpec getMakeInvisibleMethodSpec(String childName, String childGetterName) {
+        return MethodSpec.methodBuilder("make" + childName + "Invisible")
+                         .addModifiers(PUBLIC)
+                         .returns(VOID)
+                         .addStatement("viewHolder." + childGetterName + ".setVisibility(android.view.View.INVISIBLE)")
+                         .build();
     }
 
     private MethodSpec getSetBackgroundColorMethodSpec(String childName, String childGetterName) {


### PR DESCRIPTION
Currently, blueprint creates ComponentView base classes
and auto-generates some common functions for Android Views,
one of which is setVisibility(), which excepts a View.VISIBLE
or similar argument. Since that arg requires knowledge of the
Android SDK (android.view.View, specifically), it's not ideal
to have presenters using it. Now, blueprint will also create
the functions showViewName(), hideViewName() and makeViewNameInvisible(),
that require no arguments, to isolate presenters from the OS/SDK