### PR TITLE
Fix Static Components

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ allprojects {
     apply plugin: 'maven'
 
     group = 'com.xfinity'
-    version = '1.2.1'
+    version = '1.2.2'
 }
 
 ext {
@@ -33,6 +33,6 @@ ext {
     groupId = 'com.xfinity'
     projectName = 'Blueprint'
     uploadName = 'blueprint'
-    publishVersion = '1.2.1'
+    publishVersion = '1.2.2'
     description = 'Blueprint for Android'
 }

--- a/library/src/main/java/com/xfinity/blueprint/model/Component.kt
+++ b/library/src/main/java/com/xfinity/blueprint/model/Component.kt
@@ -16,6 +16,14 @@ import com.xfinity.blueprint.presenter.DefaultComponentPresenter
 
 interface ComponentModel
 
+/**
+ * StaticComponent are Components that have no Model or Presentation, just a layout that needs to be inflated and added.
+ * Having a Model with no data will cause the DiffUtil Callback to always flag a Component as "new" and re-add it whenever
+ * the screen is presented, which can cause blinking and other UI artifacts.  We'll use StaticComponent to add a default
+ * Model that contains the viewType so that these types of Components are ignored in the Diff calculation.
+ */
+data class StaticComponentModel(val viewType: Int) : ComponentModel
+
 data class Component(val model: ComponentModel,
                      val viewType: Int,
                      val presenter: ComponentPresenter<*, *>? = null) {
@@ -24,5 +32,5 @@ data class Component(val model: ComponentModel,
      *  Alternate constructor for creating components that are just a static view, with no presentation necessary.
      *  Meant for things like dividers, headers, footers, etc.
      */
-    constructor(viewType: Int) : this(object: ComponentModel {}, viewType, DefaultComponentPresenter())
+    constructor(viewType: Int) : this(StaticComponentModel(viewType), viewType, DefaultComponentPresenter())
 }

--- a/library/src/main/java/com/xfinity/blueprint/view/ScreenViewDelegate.kt
+++ b/library/src/main/java/com/xfinity/blueprint/view/ScreenViewDelegate.kt
@@ -117,7 +117,8 @@ open class ScreenViewDelegate(componentRegistry: ComponentRegistry,
 
 }
 
-class DefaultComponentDiffCallback(val oldComponents: List<Component>, val newComponents: List<Component>) : DiffUtil.Callback() {
+open class DefaultComponentDiffCallback(protected val oldComponents: List<Component>,
+                                        protected val newComponents: List<Component>) : DiffUtil.Callback() {
     override fun areItemsTheSame(oldItemPosition: Int, newItemPosition: Int): Boolean {
         return (oldComponents[oldItemPosition].viewType == newComponents[newItemPosition].viewType)
                 && areContentsTheSame(oldItemPosition, newItemPosition)


### PR DESCRIPTION
 StaticComponent are Components that have no Model or Presentation, just a layout that needs to be inflated and added. Having a Model with no data will cause the DiffUtil Callback to always flag a Component as "new" and re-add it whenever the screen is presented, which can cause blinking and other UI artifacts.  

We'll use StaticComponentModel to add a default Model that contains the viewType so that these types of Components are ignored in the Diff calculation.