### PR TITLE
Generalize loading indicators

### DIFF
--- a/app/src/main/java/com/xfinity/blueprint_sample/mvp/presenter/ArchitectSamplePresenter.kt
+++ b/app/src/main/java/com/xfinity/blueprint_sample/mvp/presenter/ArchitectSamplePresenter.kt
@@ -66,7 +66,7 @@ class ArchitectSamplePresenter(override val componentEventManager: ComponentEven
             screenComponents.add(Component(model.headerModel, AppComponentRegistry.HeaderView_VIEW_TYPE))
 
             if (!model.headerModel.enabled) {
-                screenComponents.add(Component(AppComponentRegistry.LoadingDotsView_VIEW_TYPE))
+                screenComponents.add(Component(AppComponentRegistry.LoadingIndicatorView_VIEW_TYPE))
 
                 Completable.complete().delay(3000, TimeUnit.MILLISECONDS)
                         .subscribeOn(Schedulers.io())
@@ -94,7 +94,7 @@ class ArchitectSamplePresenter(override val componentEventManager: ComponentEven
 
 
         if (model.headerModel.enabled && !model.footerModel.enabled) {
-            screenComponents.add(Component(AppComponentRegistry.LoadingDotsView_VIEW_TYPE))
+            screenComponents.add(Component(AppComponentRegistry.LoadingIndicatorView_VIEW_TYPE))
 
             Completable.complete().delay(3000, TimeUnit.MILLISECONDS)
                     .subscribeOn(Schedulers.io())

--- a/app/src/main/java/com/xfinity/blueprint_sample/mvp/presenter/CustomScreenViewPresenter.kt
+++ b/app/src/main/java/com/xfinity/blueprint_sample/mvp/presenter/CustomScreenViewPresenter.kt
@@ -67,7 +67,7 @@ class CustomScreenViewPresenter(override val componentEventManager: ComponentEve
             screenComponents.add(Component(model.headerModel, AppComponentRegistry.HeaderView_VIEW_TYPE))
 
             if (!model.headerModel.enabled) {
-                screenComponents.add(Component(AppComponentRegistry.LoadingDotsView_VIEW_TYPE))
+                screenComponents.add(Component(AppComponentRegistry.LoadingIndicatorView_VIEW_TYPE))
 
                 Completable.complete().delay(3000, TimeUnit.MILLISECONDS)
                         .subscribeOn(Schedulers.io())
@@ -95,7 +95,7 @@ class CustomScreenViewPresenter(override val componentEventManager: ComponentEve
 
 
         if (model.headerModel.enabled && !model.footerModel.enabled) {
-            screenComponents.add(Component(AppComponentRegistry.LoadingDotsView_VIEW_TYPE))
+            screenComponents.add(Component(AppComponentRegistry.LoadingIndicatorView_VIEW_TYPE))
 
             Completable.complete().delay(3000, TimeUnit.MILLISECONDS)
                     .subscribeOn(Schedulers.io())

--- a/app/src/main/java/com/xfinity/blueprint_sample/mvp/presenter/DynamicScreenPresenter.kt
+++ b/app/src/main/java/com/xfinity/blueprint_sample/mvp/presenter/DynamicScreenPresenter.kt
@@ -49,7 +49,7 @@ class DynamicScreenPresenter(override val componentEventManager: ComponentEventM
 
             if (!model.headerModel.enabled) {
                 screenComponents.add(Component(object : ComponentModel {},
-                    AppComponentRegistry.LoadingDotsView_VIEW_TYPE, DefaultComponentPresenter()))
+                    AppComponentRegistry.LoadingIndicatorView_VIEW_TYPE, DefaultComponentPresenter()))
                 val timer = Timer()
                 timer.schedule(object : TimerTask() {
                     override fun run() {
@@ -81,7 +81,7 @@ class DynamicScreenPresenter(override val componentEventManager: ComponentEventM
 
         if (model.headerModel.enabled && !model.footerModel.enabled) {
             screenComponents.add(Component(object : ComponentModel {},
-                AppComponentRegistry.LoadingDotsView_VIEW_TYPE, DefaultComponentPresenter()))
+                AppComponentRegistry.LoadingIndicatorView_VIEW_TYPE, DefaultComponentPresenter()))
             val timer = Timer()
             timer.schedule(object : TimerTask() {
                 override fun run() {

--- a/app/src/main/java/com/xfinity/blueprint_sample/mvp/view/LoadingIndicatorView.kt
+++ b/app/src/main/java/com/xfinity/blueprint_sample/mvp/view/LoadingIndicatorView.kt
@@ -20,20 +20,19 @@ import com.xfinity.blueprint.view.ComponentViewBinder
 import com.xfinity.blueprint_annotations.ComponentViewClass
 import com.xfinity.blueprint_annotations.ComponentViewHolder
 import com.xfinity.blueprint_annotations.ComponentViewHolderBinder
-import com.xfinity.blueprint_sample.R
 
-@ComponentViewClass(viewHolderClass = LoadingDotsViewHolder::class)
-class LoadingDotsView : LoadingDotsViewBase()
+@ComponentViewClass(viewHolderClass = LoadingIndicatorViewHolder::class)
+class LoadingIndicatorView : LoadingIndicatorViewBase()
 
-@ComponentViewHolder(viewType = "loading_dots_view")
-class LoadingDotsViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView)
+@ComponentViewHolder(viewType = "loading_indicator_view")
+class LoadingIndicatorViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView)
 
 @ComponentViewHolderBinder
-class LoadingDotsViewBinder : ComponentViewBinder<LoadingDotsViewHolder> {
+class LoadingIndicatorViewBinder : ComponentViewBinder<LoadingIndicatorViewHolder> {
 
     override fun bind(componentPresenter: ComponentPresenter<ComponentView<*>, ComponentModel>,
-                      componentView: ComponentView<out LoadingDotsViewHolder>,
-                      viewHolder: LoadingDotsViewHolder, position: Int) {
+                      componentView: ComponentView<out LoadingIndicatorViewHolder>,
+                      viewHolder: LoadingIndicatorViewHolder, position: Int) {
         //if there were any binding, it would go here
     }
 }

--- a/app/src/main/res/layout/fab_toolbar_screen_view.xml
+++ b/app/src/main/res/layout/fab_toolbar_screen_view.xml
@@ -53,7 +53,7 @@
         </in.srain.cube.views.ptr.PtrClassicFrameLayout>
 
         <com.xfinity.loadingdots.LoadingDots
-            android:id="@+id/loading_dots"
+            android:id="@+id/loading_indicator"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:visibility="gone"

--- a/app/src/main/res/layout/loading_indicator_view.xml
+++ b/app/src/main/res/layout/loading_indicator_view.xml
@@ -15,10 +15,11 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content">
 
-    <com.xfinity.loadingdots.LoadingDots
-        android:id="@+id/loading_dots"
+    <ProgressBar
+        android:id="@+id/loading_indicator"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_margin="24dp"
-        android:layout_gravity="center_horizontal"/>
+        android:layout_gravity="center_horizontal"
+        android:indeterminate="true"/>
 </FrameLayout>

--- a/architecture/src/main/java/com/xfinity/blueprint/architecture/Architect.kt
+++ b/architecture/src/main/java/com/xfinity/blueprint/architecture/Architect.kt
@@ -25,7 +25,7 @@ abstract class DefaultArchitect<out T : DefaultScreenView>(override val componen
 
     override fun initBlueprint(layout: View, presenter: ScreenPresenter<T>, actionBar: ActionBar?) {
         container = layout.findViewById(R.id.container)
-        loadingDots = layout.findViewById(R.id.loading_dots)
+        loadingDots = layout.findViewById(R.id.loading_indicator)
         recyclerView = layout.findViewById(R.id.recycler_view) as androidx.recyclerview.widget.RecyclerView
         ptrFrame = layout.findViewById(R.id.ptr_frame)
         screenViewDelegate = ScreenViewDelegate(componentRegistry, loadingDots, recyclerView)

--- a/architecture/src/main/res/layout/screen_view.xml
+++ b/architecture/src/main/res/layout/screen_view.xml
@@ -17,10 +17,11 @@
 
     </in.srain.cube.views.ptr.PtrClassicFrameLayout>
 
-    <com.xfinity.loadingdots.LoadingDots
-        android:id="@+id/loading_dots"
+    <ProgressBar
+        android:id="@+id/loading_indicator"
         android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
         android:layout_gravity="center"
-        android:visibility="gone"/>
+        android:layout_height="wrap_content"
+        android:visibility="gone"
+        android:indeterminate="true"/>
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/architecture/src/main/res/layout/toolbar_screen_view.xml
+++ b/architecture/src/main/res/layout/toolbar_screen_view.xml
@@ -52,11 +52,12 @@
 
         </in.srain.cube.views.ptr.PtrClassicFrameLayout>
 
-        <com.xfinity.loadingdots.LoadingDots
-            android:id="@+id/loading_dots"
+        <ProgressBar
+            android:id="@+id/loading_indicator"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:visibility="gone"
+            android:indeterminate="true"
             app:layout_constraintTop_toBottomOf="@+id/appbar"
             app:layout_constraintLeft_toLeftOf="parent"
             app:layout_constraintRight_toRightOf="parent"

--- a/sample-library-app/src/main/java/com/xfinity/blueprint_sample_library_app/mvp/view/LoadingDotsView.kt
+++ b/sample-library-app/src/main/java/com/xfinity/blueprint_sample_library_app/mvp/view/LoadingDotsView.kt
@@ -25,7 +25,7 @@ import com.xfinity.blueprint_sample_library_app.R
 @ComponentViewClass(viewHolderClass = LoadingDotsViewHolder::class)
 class LoadingDotsView : LoadingDotsViewBase()
 
-@ComponentViewHolder(viewType = "loading_dots_view")
+@ComponentViewHolder(viewType = "loading_indicator_view")
 class LoadingDotsViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView)
 
 @ComponentViewHolderBinder

--- a/sample-library-app/src/main/res/layout/loading_indicator_view.xml
+++ b/sample-library-app/src/main/res/layout/loading_indicator_view.xml
@@ -15,10 +15,11 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content">
 
-    <com.xfinity.loadingdots.LoadingDots
-        android:id="@+id/loading_dots"
+    <ProgressBar
+        android:id="@+id/loading_indicator"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_margin="24dp"
-        android:layout_gravity="center_horizontal"/>
+        android:layout_gravity="center_horizontal"
+        android:indeterminate="true"/>
 </FrameLayout>

--- a/sample-library/src/main/java/com/xfinity/blueprint_sample_library/mvp/view/LoadingDotsView.kt
+++ b/sample-library/src/main/java/com/xfinity/blueprint_sample_library/mvp/view/LoadingDotsView.kt
@@ -25,7 +25,7 @@ import com.xfinity.blueprint_sample_library.R
 @ComponentViewClass(viewHolderClass = LoadingDotsViewHolder::class)
 class LoadingDotsView : LoadingDotsViewBase()
 
-@ComponentViewHolder(viewType = "loading_dots_view")
+@ComponentViewHolder(viewType = "loading_indicator_view")
 class LoadingDotsViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView)
 
 @ComponentViewHolderBinder

--- a/sample-library/src/main/res/layout/loading_indicator_view.xml
+++ b/sample-library/src/main/res/layout/loading_indicator_view.xml
@@ -16,7 +16,7 @@
     android:layout_height="wrap_content">
 
     <com.xfinity.loadingdots.LoadingDots
-        android:id="@+id/loading_dots"
+        android:id="@+id/loading_indicator"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_margin="24dp"


### PR DESCRIPTION
Change naming to be more general, and default to more generic loading indicator, rather than xfinity loading dots.