### PR TITLE
Decouple pause/resume from component event management

### DIFF
--- a/architecture/src/main/java/com/xfinity/blueprint/architecture/activity/ScreenViewActivity.kt
+++ b/architecture/src/main/java/com/xfinity/blueprint/architecture/activity/ScreenViewActivity.kt
@@ -5,7 +5,7 @@ import android.view.Menu
 import android.view.MenuItem
 import androidx.appcompat.app.AppCompatActivity
 import com.xfinity.blueprint.architecture.*
-import com.xfinity.blueprint.presenter.ComponentEventHandler
+import com.xfinity.blueprint.presenter.PauseResumeHandler
 import com.xfinity.blueprint.presenter.ScreenPresenter
 
 abstract class ToolbarScreenViewActivity<T: DefaultScreenView> : ScreenViewActivity<T>() {
@@ -42,12 +42,12 @@ abstract class ScreenViewActivity<T: DefaultScreenView> : AppCompatActivity() {
 
     override fun onResume() {
         super.onResume()
-        (presenter as? ComponentEventHandler)?.resume()
+        (presenter as? PauseResumeHandler)?.resume()
     }
 
     override fun onPause() {
         super.onPause()
-        (presenter as? ComponentEventHandler)?.pause()
+        (presenter as? PauseResumeHandler)?.pause()
     }
 
     override fun onCreateOptionsMenu(menu: Menu?): Boolean {

--- a/architecture/src/main/java/com/xfinity/blueprint/architecture/fragment/ScreenViewFragment.kt
+++ b/architecture/src/main/java/com/xfinity/blueprint/architecture/fragment/ScreenViewFragment.kt
@@ -6,6 +6,7 @@ import androidx.appcompat.app.AppCompatActivity
 import com.xfinity.blueprint.architecture.*
 import com.xfinity.blueprint.architecture.activity.setupViews
 import com.xfinity.blueprint.presenter.ComponentEventHandler
+import com.xfinity.blueprint.presenter.PauseResumeHandler
 import com.xfinity.blueprint.presenter.ScreenPresenter
 
 interface TaggedFragment{
@@ -40,12 +41,12 @@ abstract class ScreenViewFragment<T: DefaultScreenView> : androidx.fragment.app.
 
     override fun onResume() {
         super.onResume()
-        (presenter as? ComponentEventHandler)?.resume()
+        (presenter as? PauseResumeHandler)?.resume()
     }
 
     override fun onPause() {
         super.onPause()
-        (presenter as? ComponentEventHandler)?.pause()
+        (presenter as? PauseResumeHandler)?.pause()
     }
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {

--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ allprojects {
     apply plugin: 'maven'
 
     group = 'com.xfinity'
-    version = '2.0.0'
+    version = '2.1.0'
 }
 
 ext {
@@ -33,6 +33,6 @@ ext {
     groupId = 'com.xfinity'
     projectName = 'Blueprint'
     uploadName = 'blueprint'
-    publishVersion = '2.0.0'
+    publishVersion = '2.1.0'
     description = 'Blueprint for Android'
 }

--- a/library/src/main/java/com/xfinity/blueprint/presenter/ComponentEventHandler.kt
+++ b/library/src/main/java/com/xfinity/blueprint/presenter/ComponentEventHandler.kt
@@ -17,14 +17,14 @@ import com.xfinity.blueprint.event.ComponentEventManager
 /**
  * A ComponentEventListener that provides APIs to register and unregister itself
  */
-interface ComponentEventHandler: ComponentEventListener {
+interface ComponentEventHandler: ComponentEventListener, PauseResumeHandler {
     val componentEventManager : ComponentEventManager
 
-    fun resume() {
+    override fun resume() {
         componentEventManager.registerListener(this)
     }
 
-    fun pause() {
+    override fun pause() {
         componentEventManager.unregisterListener(this)
     }
 }

--- a/library/src/main/java/com/xfinity/blueprint/presenter/PauseResumeHandler.kt
+++ b/library/src/main/java/com/xfinity/blueprint/presenter/PauseResumeHandler.kt
@@ -1,0 +1,6 @@
+package com.xfinity.blueprint.presenter
+
+interface PauseResumeHandler {
+    fun pause()
+    fun resume()
+}


### PR DESCRIPTION
It is convenient for the presenter to get automatically
notified on pause/resume, but not every presenter needs
to handle component events. Allow presenters to implement
pause/resume functionality without needing to implement the
componenteventhandler interface.