### PR TITLE
Allow Component ViewHolders to inherit from BaseClasses

### DIFF
--- a/app/src/main/java/com/xfinity/blueprint_sample/mvp/view/DataItemView.kt
+++ b/app/src/main/java/com/xfinity/blueprint_sample/mvp/view/DataItemView.kt
@@ -27,7 +27,13 @@ class DataItemView : DataItemViewBase() {
 }
 
 @ComponentViewHolder(viewType = "data_item_view")
-class DataItemViewHolder(itemView: View) : androidx.recyclerview.widget.RecyclerView.ViewHolder(itemView) {
-    val data : TextView = itemView.findViewById(R.id.data) as TextView
-    val image: ImageView = itemView.findViewById(R.id.image) as ImageView
+class DataItemViewHolder(itemView: View) : BaseViewHolder(itemView)
+
+//Example of how to create a base class for ViewHolders.  This is useful if you expect to have
+// many components presenting the same or similar types of views, but laid out differently.  Using
+// a ViewHolder base class and nullable views, a single large ViewHolder class can be reused
+// across many components without redefining all the individual views themselves.
+open class BaseViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
+    val data : TextView? = itemView.findViewById(R.id.data) as? TextView
+    val image: ImageView? = itemView.findViewById(R.id.image) as? ImageView
 }

--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ allprojects {
     }
 
     group = 'com.xfinity'
-    version = '2.2.0'
+    version = '2.3.0'
 }
 
 ext {
@@ -31,6 +31,6 @@ ext {
     groupId = 'com.xfinity'
     projectName = 'Blueprint'
     uploadName = 'blueprint'
-    publishVersion = '2.2.0'
+    publishVersion = '2.3.0-SNAPSHOT'
     description = 'Blueprint for Android'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ allprojects {
     }
 
     group = 'com.xfinity'
-    version = '2.3.0'
+    version = '2.4.0'
 }
 
 ext {
@@ -31,6 +31,6 @@ ext {
     groupId = 'com.xfinity'
     projectName = 'Blueprint'
     uploadName = 'blueprint'
-    publishVersion = '2.3.0'
+    publishVersion = '2.4.0'
     description = 'Blueprint for Android'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,6 @@ ext {
     groupId = 'com.xfinity'
     projectName = 'Blueprint'
     uploadName = 'blueprint'
-    publishVersion = '2.3.0-SNAPSHOT'
+    publishVersion = '2.3.0'
     description = 'Blueprint for Android'
 }

--- a/compiler/src/main/java/com/xfinity/blueprint_compiler/BlueprintProcessor.kt
+++ b/compiler/src/main/java/com/xfinity/blueprint_compiler/BlueprintProcessor.kt
@@ -95,8 +95,7 @@ class BlueprintProcessor : AbstractProcessor() {
             val methodNames = mutableListOf<String>()
 
             for (supertype in processingEnv.typeUtils.directSupertypes(annotatedElement.asType())) {
-                val declared =
-                    supertype as DeclaredType //you should of course check this is possible first
+                val declared = supertype as DeclaredType
                 val supertypeElement: Element = declared.asElement()
                 processViewHolderElement(supertypeElement, methodNames, children)
             }

--- a/compiler/src/main/java/com/xfinity/blueprint_compiler/BlueprintProcessor.kt
+++ b/compiler/src/main/java/com/xfinity/blueprint_compiler/BlueprintProcessor.kt
@@ -20,17 +20,21 @@ import com.xfinity.blueprint_annotations.DefaultPresenterConstructor
 import org.apache.commons.lang3.tuple.ImmutablePair
 import org.apache.commons.lang3.tuple.Pair
 import java.io.IOException
+import java.util.Locale
 import javax.annotation.processing.AbstractProcessor
 import javax.annotation.processing.ProcessingEnvironment
 import javax.annotation.processing.Processor
 import javax.annotation.processing.RoundEnvironment
 import javax.lang.model.SourceVersion
+import javax.lang.model.element.Element
 import javax.lang.model.element.ElementKind
 import javax.lang.model.element.ExecutableElement
 import javax.lang.model.element.TypeElement
 import javax.lang.model.element.VariableElement
+import javax.lang.model.type.DeclaredType
 import javax.lang.model.type.MirroredTypeException
 import javax.lang.model.type.TypeMirror
+
 
 @AutoService(Processor::class)
 class BlueprintProcessor : AbstractProcessor() {
@@ -90,39 +94,15 @@ class BlueprintProcessor : AbstractProcessor() {
             val children = mutableMapOf<String, String>()
             val methodNames = mutableListOf<String>()
 
-            for (enclosedElement in annotatedElement.getEnclosedElements()) { // We only look at fields
-                if (enclosedElement.kind == ElementKind.METHOD) {
-                    methodNames.add(enclosedElement.simpleName.toString().toLowerCase())
-                }
+            for (supertype in processingEnv.typeUtils.directSupertypes(annotatedElement.asType())) {
+                val declared =
+                    supertype as DeclaredType //you should of course check this is possible first
+                val supertypeElement: Element = declared.asElement()
+                processViewHolderElement(supertypeElement, methodNames, children)
             }
-            for (enclosedElement in annotatedElement.getEnclosedElements()) { // We only look at fields
-                if (enclosedElement.kind.isField) {
-                    val variable = enclosedElement as VariableElement
-                    val variableName = enclosedElement.getSimpleName().toString()
 
-                    //we'll only generate methods for this field if this class has
-                    // a getter for the field. We'll assume a naming convention of getFieldName()
-                    var hasGetter = false
-                    for (methodName in methodNames) {
-                        if (methodName == "get${variableName.toLowerCase()}") {
-                            hasGetter = true
-                            break
-                        }
-                    }
-                    if (!hasGetter) {
-                        continue
-                    }
-                    if (isEditText(variable)) {
-                        children[variableName] = "android.widget.EditText"
-                    } else if (isTextView(variable)) {
-                        children[variableName] = "android.widget.TextView"
-                    } else if (isImageView(variable)) {
-                        children[variableName] = "android.widget.ImageView"
-                    } else if (isAndroidView(variable)) {
-                        children[variableName] = "android.view.View"
-                    }
-                }
-            }
+            processViewHolderElement(annotatedElement, methodNames, children)
+
             val componentViewInfo = ComponentViewInfo(viewType, viewHolderClassName)
             componentViewInfo.children = children
             componentViewInfoList.add(componentViewInfo)
@@ -181,6 +161,46 @@ class BlueprintProcessor : AbstractProcessor() {
             }
         }
         return true
+    }
+
+    private fun processViewHolderElement(element: Element, methodNames: MutableList<String>,
+                                         children: MutableMap<String, String>) {
+        for (enclosedElement in element.enclosedElements) {
+            if (enclosedElement.kind == ElementKind.METHOD) {
+                methodNames.add(enclosedElement.simpleName.toString().lowercase(Locale.getDefault()))
+            }
+        }
+
+        if (methodNames.isNotEmpty()) {
+            for (enclosedElement in element.enclosedElements) {
+                if (enclosedElement.kind.isField) {
+                    val variable = enclosedElement as VariableElement
+                    val variableName = enclosedElement.getSimpleName().toString()
+
+                    //we'll only generate methods for this field if this class has
+                    // a getter for the field. We'll assume a naming convention of getFieldName()
+                    var hasGetter = false
+                    for (methodName in methodNames) {
+                        if (methodName == "get${variableName.lowercase(Locale.getDefault())}") {
+                            hasGetter = true
+                            break
+                        }
+                    }
+                    if (!hasGetter) {
+                        continue
+                    }
+                    if (isEditText(variable)) {
+                        children[variableName] = "android.widget.EditText"
+                    } else if (isTextView(variable)) {
+                        children[variableName] = "android.widget.TextView"
+                    } else if (isImageView(variable)) {
+                        children[variableName] = "android.widget.ImageView"
+                    } else if (isAndroidView(variable)) {
+                        children[variableName] = "android.view.View"
+                    }
+                }
+            }
+        }
     }
 
     private fun getFullClassName(element: TypeElement): String {


### PR DESCRIPTION
This commit allows ComponentViewHolder-annotated ViewHolder classes to inherit, and automatically add getter methods for both the base class and the subclass into the ComponetView class's generated supertype

This means that you can define generic ViewHolder classes that contain the same types of data with the same names, and then use it for many different components, without needing to redefine the variables in each one.

This means that you can potentially use one ViewHolder base class to represent a large family of components, and for each of the components, the ComponentViewHolder-annotated class is only one line long, as shown in the sample.